### PR TITLE
lib/posts-handler.js で出力している閲覧のログに、ユーザーエージェントの値の追加

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -22,7 +22,8 @@ function handle(req, res) {
         console.info(
           `閲覧されました: user: ${req.user}, ` +
           `trackingId: ${cookies.get(trackingIdKey) },` +
-          `remoteAddress: ${req.connection.remoteAddress} `
+          `remoteAddress: ${req.connection.remoteAddress}, ` +
+          `userAgent: ${req.headers['user-agent']} `
           );
       });
       break;


### PR DESCRIPTION
マージ不要です。